### PR TITLE
Fix robustness issues with multiple behaviors

### DIFF
--- a/compare_gt.py
+++ b/compare_gt.py
@@ -93,6 +93,7 @@ def evaluate_ground_truth(args):
     # )
 
     middle_threshold = np.sort(args.iou_thresholds)[int(np.floor(len(args.iou_thresholds) / 2))]
+    
     # Create a copy to avoid SettingWithCopyWarning
     subset_df = performance_df[performance_df['threshold'] == middle_threshold].copy()
     
@@ -246,7 +247,7 @@ def generate_iou_scan(all_annotations, stitch_scan, filter_scan, threshold_scan,
                 performance_df.append(pd.DataFrame(new_performance))
 
     if not performance_df:
-        warnings.warn(f"No valid ground truth and prediction pairs found for behavior {args.behavior} across all files. Cannot generate performance metrics.")
+        warnings.warn(f"No valid ground truth and prediction pairs found for behavior across all files. Cannot generate performance metrics.")
         # Return an empty DataFrame with expected columns to prevent downstream errors
         return pd.DataFrame(columns=['stitch', 'filter', 'threshold', 'tp', 'fn', 'fp', 'pr', 're', 'f1'])
 


### PR DESCRIPTION
**Issue Summary**
When processing projects containing multiple behaviors, the code would fail with various errors:

- TypeError: 'KeysViewHDF5' object is not subscriptable when trying to access prediction keys
- ValueError: No objects to concatenate when working with empty behavior datasets
- IndexError: single positional indexer is out-of-bounds when trying to access data in empty DataFrames

**Changes**

- Fixed HDF5 key handling by properly converting `KeysViewHDF5` to list
- Added robust handling for empty DataFrames throughout prediction processing:
  - Added check for empty `bout_dfs` list before concatenation
  - Added safety check for empty DataFrames in `_link_identities`
  - Improved `_sort_predictions` to properly handle cases with no valid predictions
  - Added handling for zero/negative values in `num_animals`
- Improved behavior list collection to properly update and return consistent results