### PR TITLE
fixing time bug for generate tables in metadata

### DIFF
--- a/jabs_utils/metadata.py
+++ b/jabs_utils/metadata.py
@@ -174,7 +174,7 @@ class VideoMetadata:
 	@property
 	def time_str(self):
 		"""Formatted version of the time string."""
-		return self._time.strftime('%Y-%m-%s %H:%M:%S')
+		return self._time.strftime('%Y-%m-%d %H:%M:%S')
 
 	@property
 	def date_start(self):


### PR DESCRIPTION
one line fix for metadata time bug (uses %s instead of %d for the day)

https://github.com/KumarLabJax/JABS-postprocess/issues/14

I didn't test that this fixed the problem, but it definitely should according to docs / time formatting