### PR TITLE
Fixing GHA secret inheritance and reverting to version 0.1.0 for PyPI

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,6 +24,7 @@ jobs:
   build:
     name: "Build Docker Image"
     needs: [format-lint, test]
+    secrets: inherit
     uses: ./.github/workflows/_build-docker-action.yml
 
   check-version-changed:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "jabs-postprocess"
-version = "0.4.0"
+version = "0.1.0"
 description = "A python library for JABS postprocessing utilities."
 readme = "README.md"
 license = "LicenseRef-PLATFORM-LICENSE-AGREEMENT-FOR-NON-COMMERCIAL-USE"

--- a/uv.lock
+++ b/uv.lock
@@ -340,7 +340,7 @@ wheels = [
 
 [[package]]
 name = "jabs-postprocess"
-version = "0.4.0"
+version = "0.1.0"
 source = { editable = "." }
 dependencies = [
     { name = "black" },


### PR DESCRIPTION
Docker action is broken on master branch due to a lack of explicit secret inheritance config on GitHub Actions yaml definition.