### PR TITLE
Patch interpolation_size argument bug

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "jabs-postprocess"
-version = "0.3.0"
+version = "0.3.1"
 description = "A python library for JABS postprocessing utilities."
 readme = "README.md"
 license = "LicenseRef-PLATFORM-LICENSE-AGREEMENT-FOR-NON-COMMERCIAL-USE"

--- a/src/jabs_postprocess/cli/main.py
+++ b/src/jabs_postprocess/cli/main.py
@@ -152,9 +152,6 @@ def evaluate_ground_truth(
         np.round(np.arange(0.05, 1.01, 0.05), 2).tolist(),
         help="List of intersection over union thresholds to scan (will be rounded to 2 decimal places).",
     ),
-    interpolation_size: int = typer.Option(
-        0, help="Number of frames to interpolate missing data"
-    ),
     filter_ground_truth: bool = typer.Option(
         False,
         help="Apply filters to ground truth data (default is only to filter predictions)",
@@ -189,7 +186,6 @@ def evaluate_ground_truth(
         stitch_scan=stitch_scan,
         filter_scan=filter_scan,
         iou_thresholds=iou_thresholds,
-        interpolation_size=interpolation_size,
         filter_ground_truth=filter_ground_truth,
         trim_time=trim_time,
     )

--- a/uv.lock
+++ b/uv.lock
@@ -340,7 +340,7 @@ wheels = [
 
 [[package]]
 name = "jabs-postprocess"
-version = "0.3.0"
+version = "0.3.1"
 source = { editable = "." }
 dependencies = [
     { name = "black" },


### PR DESCRIPTION
This PR removes the unused `--interpolation-size` argument from the `evaluate-ground-truth` command.

This argument was incorrectly being passed to the `evaluate_ground_truth` function in `compare_gt`, which does not have that keyword argument.

The argument does not appear to have been in use prior to our CLI refactor, and so we are removing it entirely.