### PR TITLE
Coerce frame interval columns to int before exploding

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "jabs-postprocess"
-version = "0.5.2"
+version = "0.5.3"
 description = "A python library for JABS postprocessing utilities."
 readme = "README.md"
 license = "LicenseRef-PLATFORM-LICENSE-AGREEMENT-FOR-NON-COMMERCIAL-USE"

--- a/src/jabs_postprocess/compare_gt.py
+++ b/src/jabs_postprocess/compare_gt.py
@@ -501,7 +501,9 @@ def _expand_intervals_to_frames(df):
     # Ensure integer frame boundaries so range() receives ints even if upstream data was cast to float
     for col in ["animal_idx", "start", "duration"]:
         if col in expanded.columns:
-            expanded[col] = pd.to_numeric(expanded[col], errors="coerce").fillna(0).astype(int)
+            expanded[col] = (
+                pd.to_numeric(expanded[col], errors="coerce").fillna(0).astype(int)
+            )
     expanded["frame"] = expanded.apply(
         lambda row: range(row["start"], row["start"] + row["duration"]), axis=1
     )

--- a/src/jabs_postprocess/compare_gt.py
+++ b/src/jabs_postprocess/compare_gt.py
@@ -498,6 +498,10 @@ def generate_output_paths(results_folder: Path):
 def _expand_intervals_to_frames(df):
     """Expand behavior intervals into per-frame rows."""
     expanded = df.copy()
+    # Ensure integer frame boundaries so range() receives ints even if upstream data was cast to float
+    for col in ["animal_idx", "start", "duration"]:
+        if col in expanded.columns:
+            expanded[col] = pd.to_numeric(expanded[col], errors="coerce").fillna(0).astype(int)
     expanded["frame"] = expanded.apply(
         lambda row: range(row["start"], row["start"] + row["duration"]), axis=1
     )

--- a/src/jabs_postprocess/compare_gt.py
+++ b/src/jabs_postprocess/compare_gt.py
@@ -499,11 +499,18 @@ def _expand_intervals_to_frames(df):
     """Expand behavior intervals into per-frame rows."""
     expanded = df.copy()
     # Ensure integer frame boundaries so range() receives ints even if upstream data was cast to float
+    # (e.g., when concatenating empty int DataFrames with dict-based DataFrames, pandas upcasts to float)
     for col in ["animal_idx", "start", "duration"]:
         if col in expanded.columns:
-            expanded[col] = (
-                pd.to_numeric(expanded[col], errors="coerce").fillna(0).astype(int)
-            )
+            # Check for NaN values which indicate data quality issues
+            if expanded[col].isna().any():
+                raise ValueError(
+                    f"Column '{col}' contains NaN values. "
+                    f"Expected valid numeric values for frame interval calculation."
+                )
+            # Convert to int, allowing for float values that can be safely cast
+            # (e.g., 5.0 -> 5, but 5.5 would truncate to 5)
+            expanded[col] = expanded[col].astype(int)
     expanded["frame"] = expanded.apply(
         lambda row: range(row["start"], row["start"] + row["duration"]), axis=1
     )

--- a/uv.lock
+++ b/uv.lock
@@ -512,7 +512,7 @@ wheels = [
 
 [[package]]
 name = "jabs-postprocess"
-version = "0.5.2"
+version = "0.5.3"
 source = { editable = "." }
 dependencies = [
     { name = "black" },


### PR DESCRIPTION
Fix for report from @michberger :
```
TypeError: 'float' object cannot be interpreted as an integer.
```

When GT annotations are missing, we synthesize “not-behavior” bouts covering the whole video. Concatenating those dummy rows onto an empty GT table makes pandas upcast numeric fields to float. Later,
  `_expand_intervals_to_frames` passed those floats to `range`, raising `TypeError: 'float' object cannot be interpreted as an integer`. The failure happened before any metrics/plots were produced.