### PR TITLE
Fix latency feature bugs, add more latency tests

### DIFF
--- a/src/jabs_postprocess/utils/project_utils.py
+++ b/src/jabs_postprocess/utils/project_utils.py
@@ -1080,10 +1080,8 @@ class BoutTable(Table):
                     / behavior_bins["percent_bout"].values,
                     weights=behavior_bins["percent_bout"].values,
                 )
-                results["latency_to_first_prediction"] = behavior_bins["start"].min()
-                results["latency_to_last_prediction"] = (
-                    behavior_bins["start"] + behavior_bins["duration"]
-                ).max()
+                results["latency_to_first_prediction"] = behavior_bins["adjusted_start"].min()
+                results["latency_to_last_prediction"] = behavior_bins["adjusted_end"].max()
 
                 # Variance requires more than one effective bout
                 if len(behavior_bins) > 1:

--- a/tests/utils/test_project_utils.py
+++ b/tests/utils/test_project_utils.py
@@ -703,6 +703,76 @@ class TestBoutTableBoutsToBinsWeightedStats:
             "Expected last prediction to end at frame 840"
         )
 
+    def test_bouts_to_bins_latency_to_first_prediction_nonzero_offset(self):
+        """Test that latency_to_first_prediction is experiment-relative, not video-local."""
+        # Arrange: Two videos at different times so the function uses real timestamps.
+        # Video 1 at 00:00 (offset 0), Video 2 at 00:05 (offset 9000 frames at 30fps).
+        # The earliest behavior bout's adjusted_start should be the result.
+        # Video 2 bout: adjusted_start = 9000 + 200 = 9200
+        # Video 1 bout: adjusted_start = 0 + 500 = 500
+        # In the 0-10 min bin, first prediction = min(500, 9200, 9800) = 500
+        # In the second scenario below, we check that a later-video bout reports correctly.
+        data = pd.DataFrame(
+            {
+                "animal_idx": [0, 0, 0],
+                "video_name": ["vid1", "vid2", "vid2"],
+                "start": [500, 200, 800],
+                "duration": [50, 30, 40],
+                "is_behavior": [1, 1, 1],
+                "exp_prefix": ["exp1"] * 3,
+                "time": [
+                    "1970-01-01 00:00:00",
+                    "1970-01-01 00:05:00",
+                    "1970-01-01 00:05:00",
+                ],
+            }
+        )
+
+        # Act — use 5-min bins so vid2 bouts land in the second bin
+        result = BoutTable.bouts_to_bins(data, bin_size_minutes=5, fps=30)
+
+        # Assert — bin 0 (0-5min) has only vid1 bout: adjusted_start = 500
+        assert result.iloc[0]["latency_to_first_prediction"] == 500, (
+            "Expected first prediction at experiment-relative frame 500"
+        )
+        # bin 1 (5-10min) has vid2 bouts: adjusted_start = 9000+200=9200 and 9000+800=9800
+        assert result.iloc[1]["latency_to_first_prediction"] == 9200, (
+            "Expected first prediction at experiment-relative frame 9200"
+        )
+
+    def test_bouts_to_bins_latency_to_last_prediction_nonzero_offset(self):
+        """Test that latency_to_last_prediction is experiment-relative, not video-local."""
+        # Arrange: Two videos at different times.
+        # Video 1 at 00:00, Video 2 at 00:05 (offset 9000 frames at 30fps).
+        # In the 5-10min bin, last prediction end = max(adjusted_end) = 9000+800+40 = 9840
+        data = pd.DataFrame(
+            {
+                "animal_idx": [0, 0, 0],
+                "video_name": ["vid1", "vid2", "vid2"],
+                "start": [200, 500, 800],
+                "duration": [30, 50, 40],
+                "is_behavior": [1, 1, 1],
+                "exp_prefix": ["exp1"] * 3,
+                "time": [
+                    "1970-01-01 00:00:00",
+                    "1970-01-01 00:05:00",
+                    "1970-01-01 00:05:00",
+                ],
+            }
+        )
+
+        # Act — use 5-min bins
+        result = BoutTable.bouts_to_bins(data, bin_size_minutes=5, fps=30)
+
+        # Assert — bin 0 (0-5min): vid1 bout ends at 200+30=230
+        assert result.iloc[0]["latency_to_last_prediction"] == 230, (
+            "Expected last prediction to end at experiment-relative frame 230"
+        )
+        # bin 1 (5-10min): vid2 bouts end at 9000+500+50=9550 and 9000+800+40=9840
+        assert result.iloc[1]["latency_to_last_prediction"] == 9840, (
+            "Expected last prediction to end at experiment-relative frame 9840"
+        )
+
     def test_bouts_to_bins_no_behavior_bouts(self):
         """Test handling when there are no behavior bouts in a bin."""
         # Arrange: Only non-behavior events


### PR DESCRIPTION
The latency_to_first_prediction and latency_to_last_prediction columns in the binned behavior data were reporting incorrect frame numbers. These columns are supposed to report frame numbers relative to the experiment start, but they were instead reporting frame numbers relative to the individual video file. This meant:

The first time bin (0–5 min) appeared correct by coincidence, since the first video starts at the experiment start (offset = 0).

All later time bins produced nonsensical values — often small frame numbers that could exceed the video's total frame count when interpreted in the experiment timeline, or that didn't match the merged bout tables.

# What was changed

_Source fix — project_utils.py:1083-1084_
The two latency calculations in BoutTable.bouts_to_bins() were changed from using the video-local start column to using the experiment-relative adjusted_start and adjusted_end columns:

## Before (buggy):
results["latency_to_first_prediction"] = behavior_bins["start"].min()
results["latency_to_last_prediction"] = (
    behavior_bins["start"] + behavior_bins["duration"]
).max()

## After (fixed):
results["latency_to_first_prediction"] = behavior_bins["adjusted_start"].min()
results["latency_to_last_prediction"] = behavior_bins["adjusted_end"].max()


start — the frame number where a bout begins within its video file (resets to 0 for each video)

adjusted_start — the frame number where a bout begins relative to the experiment start, computed as time_to_frame(video_timestamp, experiment_start, fps) + start

adjusted_end — adjusted_start + duration, the experiment-relative frame where the bout ends


## Regression tests — test_project_utils.py
Two new test methods were added:

test_bouts_to_bins_latency_to_first_prediction_nonzero_offset — constructs a DataFrame with two videos at different timestamps (00:00:00 and 00:05:00), uses 5-minute bins, and asserts that the second bin's latency_to_first_prediction equals 9000 + 200 = 9200 (experiment-relative), not 200 (video-local).

test_bouts_to_bins_latency_to_last_prediction_nonzero_offset — same multi-video setup, asserts that the second bin's latency_to_last_prediction equals 9000 + 800 + 40 = 9840, not 840.

The existing single-video tests (which use time="1970-01-01 00:00:00" where adjusted_start == start) were preserved and still pass. The new tests use multiple distinct timestamps specifically because bouts_to_bins() falls back to epoch when all timestamps are identical — multi-video data is required to exercise the bug.