### PR TITLE
Update pose version requirement and optimize sum usage in pandas

### DIFF
--- a/src/jabs_postprocess/compare_gt.py
+++ b/src/jabs_postprocess/compare_gt.py
@@ -454,7 +454,7 @@ def generate_iou_scan(
     # Aggregate over animals
     performance_df = (
         performance_df.groupby(["stitch", "filter", "threshold"])[["tp", "fn", "fp"]]
-        .apply(np.sum)
+        .sum()
         .reset_index()
     )
     # Re-calculate PR/RE/F1

--- a/src/jabs_postprocess/utils/metadata.py
+++ b/src/jabs_postprocess/utils/metadata.py
@@ -5,7 +5,7 @@ from pathlib import Path
 
 import yaml
 
-POSE_REGEX_STR = "_pose_est_v([2-6]).h5"
+POSE_REGEX_STR = "_pose_est_v([2-8]).h5"
 PREDICTION_REGEX_STR = "_behavior.h5"
 FEATURE_REGEX_STR = "features.h5"
 DATE_REGEX_STR = "[0-9]{4}-[0-9]{2}-[0-9]{2}"


### PR DESCRIPTION
This pull request makes two targeted improvements: it updates a regular expression to support newer pose estimation versions and simplifies the aggregation logic in the IoU scan generation function.

**Regex and metadata updates:**
* Updated `POSE_REGEX_STR` in `metadata.py` to support pose estimation versions 2 through 8, instead of just 2 through 6.

**Performance aggregation logic:**
* Simplified the aggregation step in `generate_iou_scan` in `compare_gt.py` by replacing `.apply(np.sum)` with `.sum()`, which is the recommended and more efficient approach for summing grouped DataFrame values.